### PR TITLE
Dockerfile version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mhart/alpine-node:0.12.2
 
-RUN npm install frontail --global
+RUN npm install frontail@3.0.0 --global
 
 ENTRYPOINT ["frontail"]
 EXPOSE 9001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mhart/alpine-node:0.12.2
 
-RUN npm install frontail@2.1.1 --global
+RUN npm install frontail --global
 
 ENTRYPOINT ["frontail"]
 EXPOSE 9001


### PR DESCRIPTION
Hi, thanks for great software. 

Shouldn't we bump Dockerfile version on each release, so that Docker Hub image gets rebuilt? My fork builds nicely =)
